### PR TITLE
Enables module publication, version:PATCH

### DIFF
--- a/build/Publish-MyModule.ps1
+++ b/build/Publish-MyModule.ps1
@@ -93,7 +93,7 @@ process {
             NuGetApiKey = $ApiKey
             Repository  = 'PSGallery'
         }
-        # Publish-Module @publishParams
+        Publish-Module @publishParams
         Write-Host "Module published successfully." -ForegroundColor Green
 
         # Tag the main branch with the new version number


### PR DESCRIPTION
Removes the comment from the `Publish-Module` command, allowing the script to publish the module to the PowerShell Gallery.