### PR TITLE
Simplifies GitHub release workflow authentication version:PATCH

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
           # git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
 
           # use PAT instead of GITHUB_TOKEN to avoid issues with permissions
-          git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
           git push origin main --force
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
           # git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
 
           # use PAT instead of GITHUB_TOKEN to avoid issues with permissions
-          git remote set-url origin https://${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://AzureStackNerd${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
           git push origin main --force
 
       - name: Create GitHub Release

--- a/EntraIdDSC/EntraIdDSC.psd1
+++ b/EntraIdDSC/EntraIdDSC.psd1
@@ -4,7 +4,7 @@
 
     # Version number of this module.
 
-    ModuleVersion = '0.2.2'
+    ModuleVersion = '0.2.3'
 
     # ID used to uniquely identify this module
     GUID = 'c6cb6bdb-fb65-425b-9579-3d49128a4ebd'


### PR DESCRIPTION
Removes the unnecessary `x-access-token` prefix from the Git remote URL in the release workflow. This streamlines authentication by directly using the provided GitHub token, potentially resolving authentication issues.