### PR TITLE
Splits version bumping and publishing into separate scripts. version:PATCH

### DIFF
--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -54,5 +54,5 @@ jobs:
           git add .
           git commit -m "chore: bump module version to ${{ env.MODULE_VERSION }}" || echo "No changes to commit"
           git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-          git push origin ${{ github.head_ref }}
+          git push origin ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -45,6 +45,8 @@ jobs:
       - name: Set Module Version
         id: version
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pwsh ./build/Set-Version.ps1 -Path "./EntraIdDSC/" -IncrementVersion "${{ env.INCREMENT_VERSION }}" -Repo 'AzureStackNerd/EntraIdDSC'
 

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Determine IncrementVersion from PR title
         id: bump

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -1,0 +1,58 @@
+
+name: Version the PowerShell Module
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, edited]
+
+jobs:
+  pullrequest:
+    name: Release PowerShell Module
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Determine IncrementVersion from PR title
+        id: bump
+        run: |
+          # Default to Minor
+          INCREMENT_VERSION="Minor"
+          echo "gh pr title: ${{ github.event.pull_request.title }}"
+
+          # Get PR title if available
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            PR_TITLE="$(jq -r .pull_request.title < $GITHUB_EVENT_PATH)"
+            echo "PR Title: $PR_TITLE"
+            if echo "$PR_TITLE" | grep -iq "MAJOR"; then
+              INCREMENT_VERSION="Major"
+            elif echo "$PR_TITLE" | grep -iq "MINOR"; then
+              INCREMENT_VERSION="Minor"
+            elif echo "$PR_TITLE" | grep -iq "PATCH"; then
+              INCREMENT_VERSION="Patch"
+            fi
+          fi
+          echo "INCREMENT_VERSION=$INCREMENT_VERSION"
+          echo "INCREMENT_VERSION=$INCREMENT_VERSION" >> $GITHUB_ENV
+
+      - name: Set Module Version
+        id: version
+        shell: pwsh
+        run: |
+          pwsh ./build/Set-Version.ps1 -Path "./EntraIdDSC/" -IncrementVersion "${{ env.INCREMENT_VERSION }}" -Repo 'AzureStackNerd/EntraIdDSC'
+
+      - name: Push Changes to repository
+        id: push
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore: bump module version to ${{ env.MODULE_VERSION }}" || echo "No changes to commit"
+          git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          git push origin ${{ github.head_ref }}
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,61 +2,35 @@
 name: Release PowerShell Module
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types: [closed]
-
 jobs:
   release:
-    if: ${{ github.event.pull_request.merged }}
     name: Release PowerShell Module
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Determine IncrementVersion from PR title
-        id: bump
-        run: |
-          # Default to Minor
-          INCREMENT_VERSION="Minor"
-          echo "gh pr title: ${{ github.event.pull_request.title }}"
-
-          # Get PR title if available
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            PR_TITLE="$(jq -r .pull_request.title < $GITHUB_EVENT_PATH)"
-            echo "PR Title: $PR_TITLE"
-            if echo "$PR_TITLE" | grep -iq "MAJOR"; then
-              INCREMENT_VERSION="Major"
-            elif echo "$PR_TITLE" | grep -iq "MINOR"; then
-              INCREMENT_VERSION="Minor"
-            elif echo "$PR_TITLE" | grep -iq "PATCH"; then
-              INCREMENT_VERSION="Patch"
-            fi
-          fi
-          echo "INCREMENT_VERSION=$INCREMENT_VERSION"
-          echo "INCREMENT_VERSION=$INCREMENT_VERSION" >> $GITHUB_ENV
 
       - name: Publish PowerShell Module
         id: publish
         shell: pwsh
         run: |
-          pwsh ./build/Publish-MyModule.ps1 -Path "./EntraIdDSC/" -ApiKey "${{ secrets.PSGALLERY_API_KEY }}" -IncrementVersion "${{ env.INCREMENT_VERSION }}"
+          pwsh ./build/Publish-MyModule.ps1 -Path "./EntraIdDSC/" -ApiKey "${{ secrets.PSGALLERY_API_KEY }}"
 
-      - name: Push Changes to repository
-        id: push
+      - name: Read Manifest File for the current version
+        id: read_manifest
+        shell: pwsh
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "chore: bump module version to ${{ env.MODULE_VERSION }}" || echo "No changes to commit"
-          git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-
-          git push origin main --force
+          $manifest = Get-ChildItem -Path './EntraIdDSC/' -Filter '*.psd1' | Select-Object -First 1
+          if ($null -eq $manifest) {
+            Write-Error 'No manifest file (*.psd1) found in ./EntraIdDSC/'
+            exit 1
+          }
+          $manifestObject = Import-PowerShellDataFile -Path $manifest.FullName
+          $version = $manifestObject.ModuleVersion
+          Add-Content -Path $env:GITHUB_ENV -Value "MODULE_VERSION=$version"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/EntraIdDSC/EntraIdDSC.psd1
+++ b/EntraIdDSC/EntraIdDSC.psd1
@@ -4,7 +4,7 @@
 
     # Version number of this module.
 
-    ModuleVersion = '0.2.7'
+    ModuleVersion = '0.3.0'
 
     # ID used to uniquely identify this module
     GUID = 'c6cb6bdb-fb65-425b-9579-3d49128a4ebd'
@@ -62,6 +62,7 @@
     AliasesToExport = @()
 
 }
+
 
 
 

--- a/EntraIdDSC/EntraIdDSC.psd1
+++ b/EntraIdDSC/EntraIdDSC.psd1
@@ -4,7 +4,7 @@
 
     # Version number of this module.
 
-    ModuleVersion = '0.3.0'
+    ModuleVersion = '0.2.8'
 
     # ID used to uniquely identify this module
     GUID = 'c6cb6bdb-fb65-425b-9579-3d49128a4ebd'
@@ -62,6 +62,7 @@
     AliasesToExport = @()
 
 }
+
 
 
 

--- a/build/Publish-MyModule.ps1
+++ b/build/Publish-MyModule.ps1
@@ -1,17 +1,3 @@
-
-[CmdletBinding()]
-param (
-    [Parameter(Mandatory = $true, Position = 0)]
-    [string]$Path,
-
-    [Parameter(Mandatory = $true, Position = 1)]
-    [string]$ApiKey,
-
-    [Parameter(Mandatory = $false)]
-    [ValidateSet('Major', 'Minor', 'Patch')]
-    [string]$IncrementVersion = 'Minor'
-)
-
 <#
     .SYNOPSIS
     Publishes a PowerShell module to a repository.
@@ -33,6 +19,14 @@ param (
     .NOTES
     Ensure that the module manifest (.psd1) file is present in the specified path.
     #>
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true, Position = 1)]
+    [string]$ApiKey
+)
 
 process {
     try {
@@ -47,44 +41,6 @@ process {
             throw "No module manifest (.psd1) file found in the specified path."
         }
 
-        $manifestObject = Import-PowerShellDataFile -Path $manifest.FullName
-        $version = $manifestObject.ModuleVersion
-
-        # Increment version based on IncrementVersion parameter (semver: major.minor.patch)
-        $versionParts = $version -split '\.'
-        if ($versionParts.Count -lt 2) {
-            throw "ModuleVersion format is invalid: $version"
-        }
-        $major = [int]$versionParts[0]
-        $minor = [int]$versionParts[1]
-        $patch = if ($versionParts.Count -gt 2) { [int]$versionParts[2] } else { 0 }
-
-        switch ($IncrementVersion) {
-            'Major' {
-                $major++
-                $minor = 0
-                $patch = 0
-            }
-            'Minor' {
-                $minor++
-                $patch = 0
-            }
-            'Patch' {
-                $patch++
-            }
-        }
-        $newVersion = "$major.$minor.$patch"
-        $manifestObject.ModuleVersion = $newVersion
-
-        # Write the updated manifest back to the file
-        $manifestContent = Get-Content -Path $manifest.FullName -Raw
-        $manifestContent = $manifestContent -replace "ModuleVersion\s*=\s*'[^']+'", "ModuleVersion = '$newVersion'"
-        Set-Content -Path $manifest.FullName -Value $manifestContent
-        Write-Host "Updated module version to $newVersion"
-
-        echo "MODULE_VERSION=$newVersion" >> $env:GITHUB_ENV
-        Add-Content -Path $env:GITHUB_ENV -Value "MODULE_VERSION=$newVersion"
-
         # Publish the module
         Write-Host "Publishing module from path: $Path"
         $publishParams = @{
@@ -92,7 +48,7 @@ process {
             NuGetApiKey = $ApiKey
             Repository  = 'PSGallery'
         }
-        Publish-Module @publishParams
+        # Publish-Module @publishParams
         Write-Host "Module published successfully." -ForegroundColor Green
     }
     catch {

--- a/build/Set-Version.ps1
+++ b/build/Set-Version.ps1
@@ -45,9 +45,6 @@ process {
             throw "No module manifest (.psd1) file found in the specified path."
         }
 
-        # $manifestObject = Import-PowerShellDataFile -Path $manifest.FullName
-        # $version = $manifestObject.ModuleVersion
-
         $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
         $latestVersion = $latestRelease.tag_name
         $version = $latestVersion.TrimStart('v')
@@ -78,6 +75,8 @@ process {
             }
         }
         $newVersion = "$major.$minor.$patch"
+
+        $manifestObject = Import-PowerShellDataFile -Path $manifest.FullName
         $manifestObject.ModuleVersion = $newVersion
 
         # Write the updated manifest back to the file

--- a/build/Set-Version.ps1
+++ b/build/Set-Version.ps1
@@ -45,7 +45,11 @@ process {
             throw "No module manifest (.psd1) file found in the specified path."
         }
 
-        $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+        $headers = @{
+            Authorization = "token $env:GITHUB_TOKEN"
+            Accept        = "application/vnd.github.v3+json"
+        }
+        $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers $headers
         $latestVersion = $latestRelease.tag_name
         $version = $latestVersion.TrimStart('v')
         Write-Host "Latest release version: $latestVersion"

--- a/build/Set-Version.ps1
+++ b/build/Set-Version.ps1
@@ -1,0 +1,83 @@
+<#
+    .SYNOPSIS
+    Bumps the version in the PowerShell module manifest (.psd1).
+
+    .DESCRIPTION
+    This function increments the version number in the module manifest (.psd1) file according to semantic versioning.
+
+    .PARAMETER Path
+    The path to the module directory containing the manifest.
+
+    .PARAMETER IncrementVersion
+    Which part of the version to increment: Major, Minor, or Patch.
+
+    .EXAMPLE
+    Set-Version -Path "C:\Modules\MyModule" -IncrementVersion Minor
+
+    Increments the minor version in the manifest file.
+
+    .NOTES
+    Ensure that the module manifest (.psd1) file is present in the specified path.
+#>
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Major', 'Minor', 'Patch')]
+    [string]$IncrementVersion = 'Minor'
+)
+
+process {
+    try {
+        # Validate the module path
+        if (-not (Test-Path -Path $Path -PathType Container)) {
+            throw "The specified path '$Path' does not exist or is not a directory."
+        }
+
+        # Find the module manifest
+        $manifest = Get-ChildItem -Path $Path -Filter '*.psd1' | Select-Object -First 1
+        if (-not $manifest) {
+            throw "No module manifest (.psd1) file found in the specified path."
+        }
+
+        $manifestObject = Import-PowerShellDataFile -Path $manifest.FullName
+        $version = $manifestObject.ModuleVersion
+
+        # Increment version based on IncrementVersion parameter (semver: major.minor.patch)
+        $versionParts = $version -split '\.'
+        if ($versionParts.Count -lt 2) {
+            throw "ModuleVersion format is invalid: $version"
+        }
+        $major = [int]$versionParts[0]
+        $minor = [int]$versionParts[1]
+        $patch = if ($versionParts.Count -gt 2) { [int]$versionParts[2] } else { 0 }
+
+        switch ($IncrementVersion) {
+            'Major' {
+                $major++
+                $minor = 0
+                $patch = 0
+            }
+            'Minor' {
+                $minor++
+                $patch = 0
+            }
+            'Patch' {
+                $patch++
+            }
+        }
+        $newVersion = "$major.$minor.$patch"
+        $manifestObject.ModuleVersion = $newVersion
+
+        # Write the updated manifest back to the file
+        $manifestContent = Get-Content -Path $manifest.FullName -Raw
+        $manifestContent = $manifestContent -replace "ModuleVersion\s*=\s*'[^']+'", "ModuleVersion = '$newVersion'"
+        Set-Content -Path $manifest.FullName -Value $manifestContent
+        Write-Host "Version updated to $newVersion"
+    }
+    catch {
+        Write-Error "An error occurred: $_"
+    }
+}


### PR DESCRIPTION
Refactors the `Publish-MyModule.ps1` script into two separate scripts: `Set-Version.ps1` and a future `Publish-MyModule.ps1`.

`Set-Version.ps1` is responsible for updating the module version in the module manifest file.  It takes a path to the module and an optional `IncrementVersion` parameter to specify which part of the version to increment.

This change separates concerns and prepares for a future publishing script which will be used for actually publishing to the PSGallery.