### PR TITLE
Restricts workflow execution to EntraIdDSC PATCH

### DIFF
--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -5,7 +5,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'EntraIdDSC/**'
     types: [opened, synchronize, edited]
+
 
 jobs:
   pullrequest:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'EntraIdDSC/**'
+
 jobs:
   release:
     name: Release PowerShell Module


### PR DESCRIPTION
This change configures the pull request and release workflows to only trigger when changes occur within the EntraIdDSC directory. This improves efficiency by preventing unnecessary workflow executions for unrelated changes.