### PR TITLE
Tweaks versioning workflow trigger

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   versioning:
-    if: contains(github.event.pull_request.labels.*.name, 'release')
+    if: github.event.label.name == 'release'
     name: Release PowerShell Module
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Adjusts the versioning workflow to trigger on labeled pull requests instead of pull request events. This ensures version bumps only happen when a 'release' label is added.