### PR TITLE
Simplifies PR title check for version increment

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -30,18 +30,14 @@ jobs:
           INCREMENT_VERSION="Minor"
           echo "gh pr title: ${{ github.event.pull_request.title }}"
 
-          # Get PR title if available
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            PR_TITLE="$(jq -r .pull_request.title < $GITHUB_EVENT_PATH)"
-            echo "PR Title: $PR_TITLE"
-            if echo "$PR_TITLE" | grep -iq "MAJOR"; then
-              INCREMENT_VERSION="Major"
-            elif echo "$PR_TITLE" | grep -iq "MINOR"; then
-              INCREMENT_VERSION="Minor"
-            elif echo "$PR_TITLE" | grep -iq "PATCH"; then
-              INCREMENT_VERSION="Patch"
-            fi
-          fi
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          echo "PR Title: $PR_TITLE"
+          if echo "$PR_TITLE" | grep -iq "MAJOR"; then
+            INCREMENT_VERSION="Major"
+          elif echo "$PR_TITLE" | grep -iq "MINOR"; then
+            INCREMENT_VERSION="Minor"
+          elif echo "$PR_TITLE" | grep -iq "PATCH"; then
+            INCREMENT_VERSION="Patch"
           echo "INCREMENT_VERSION=$INCREMENT_VERSION"
           echo "INCREMENT_VERSION=$INCREMENT_VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
Removes unnecessary conditional check for pull request event.

The previous logic checked if the event name was "pull_request" before extracting the title. This is redundant as the workflow is already triggered by pull request events, ensuring the title is always available.