### PR TITLE
Fixes tags in module manifest, version:PATCH

### DIFF
--- a/EntraIdDSC/EntraIdDSC.psd1
+++ b/EntraIdDSC/EntraIdDSC.psd1
@@ -23,7 +23,7 @@
 
     PrivateData = @{
     PSData = @{
-        Tags = @('Entra', 'EntraId', 'DSC', 'AzureAD', 'Identity', 'Desired State')
+        Tags = @('Entra', 'EntraId', 'DSC', 'AzureAD', 'Identity', 'Desired', 'State')
         LicenseUri = 'https://opensource.org/licenses/MIT'
         ProjectUri = 'https://github.com/AzureStackNerd/EntraIdDSC/'
         ReleaseNotes = 'Fix tags in module manifest'


### PR DESCRIPTION
Corrects a typo in the module manifest tags by changing "Desired State" to "Desired" and "State".

This change improves the discoverability and categorization of the module in relevant repositories.