### PR TITLE
Handles pre-existing group members gracefully version:PATCH

### DIFF
--- a/EntraIdDSC/EntraIdDSC.psd1
+++ b/EntraIdDSC/EntraIdDSC.psd1
@@ -4,7 +4,7 @@
 
     # Version number of this module.
 
-    ModuleVersion = '1.0.3'
+    ModuleVersion = '1.0.4'
 
     # ID used to uniquely identify this module
     GUID = 'c6cb6bdb-fb65-425b-9579-3d49128a4ebd'
@@ -71,6 +71,7 @@
     AliasesToExport = @()
 
 }
+
 
 
 

--- a/EntraIdDSC/public/Add-EntraIdGroupMember.ps1
+++ b/EntraIdDSC/public/Add-EntraIdGroupMember.ps1
@@ -77,16 +77,18 @@ function Add-EntraIdGroupMember {
                     if ($null -ne $memberUserObj) {
                         $memberUserId = $memberUserObj.Id
                         $addMemberParams = @{
-                            GroupId = $GroupId
+                            GroupId           = $GroupId
                             DirectoryObjectId = $memberUserId
                         }
                         try {
                             New-MgGroupMember @addMemberParams
                             Write-Output "Added Member (user) $memberEntry to group $GroupDisplayName ($GroupId)."
-                        } catch {
+                        }
+                        catch {
                             if ($_.Exception.Message -match "already a member") {
                                 Write-Warning "Member $memberEntry is already in the group. Skipping."
-                            } else {
+                            }
+                            else {
                                 throw
                             }
                         }
@@ -104,16 +106,18 @@ function Add-EntraIdGroupMember {
                     if ($null -ne $memberGroupObj) {
                         $memberGroupId = $memberGroupObj.Id
                         $addMemberParams = @{
-                            GroupId = $GroupId
+                            GroupId           = $GroupId
                             DirectoryObjectId = $memberGroupId
                         }
                         try {
                             New-MgGroupMember @addMemberParams
                             Write-Output "Added Member (group) $memberEntry to group $GroupDisplayName ($GroupId)."
-                        } catch {
+                        }
+                        catch {
                             if ($_.Exception.Message -match "already a member") {
                                 Write-Warning "Member $memberEntry is already in the group. Skipping."
-                            } else {
+                            }
+                            else {
                                 throw
                             }
                         }
@@ -127,16 +131,18 @@ function Add-EntraIdGroupMember {
                         if ($null -ne $memberSpnObj) {
                             $memberSpnId = $memberSpnObj.Id
                             $addMemberParams = @{
-                                GroupId = $GroupId
+                                GroupId           = $GroupId
                                 DirectoryObjectId = $memberSpnId
                             }
                             try {
                                 New-MgGroupMember @addMemberParams
                                 Write-Output "Added Member (service principal) $memberEntry to group $GroupDisplayName ($GroupId)."
-                            } catch {
+                            }
+                            catch {
                                 if ($_.Exception.Message -match "already a member") {
                                     Write-Warning "Member $memberEntry is already in the group. Skipping."
-                                } else {
+                                }
+                                else {
                                     throw
                                 }
                             }


### PR DESCRIPTION
Updates the `Add-EntraIdGroupMember` function to handle cases where a member already exists in the target group. Instead of throwing an error, it now issues a warning and continues processing other members. This prevents the function from failing when encountering existing members.