### PR TITLE
Ensures group creation confirmation is visible version:PATCH

### DIFF
--- a/EntraIdDSC/EntraIdDSC.psd1
+++ b/EntraIdDSC/EntraIdDSC.psd1
@@ -4,7 +4,7 @@
 
     # Version number of this module.
 
-    ModuleVersion = '1.0.4'
+    ModuleVersion = '1.0.5'
 
     # ID used to uniquely identify this module
     GUID = 'c6cb6bdb-fb65-425b-9579-3d49128a4ebd'
@@ -71,6 +71,7 @@
     AliasesToExport = @()
 
 }
+
 
 
 

--- a/EntraIdDSC/public/Set-EntraIdGroup.ps1
+++ b/EntraIdDSC/public/Set-EntraIdGroup.ps1
@@ -96,6 +96,7 @@ function Set-EntraIdGroup {
             if ([string]::IsNullOrWhiteSpace($AdministrativeUnit)) {
                 if ($PSCmdlet.ShouldProcess("Group '$DisplayName'", "Create group with parameters $($newGroupParams | ConvertTo-Json)")) {
                     $group = New-MgGroup @newGroupParams
+                    Write-Output "Created group '$DisplayName' ($GroupMembershipType membership)"
                 }
             }
             else {
@@ -119,10 +120,9 @@ function Set-EntraIdGroup {
                         BodyParameter        = $bodyParams
                     }
                     New-MgDirectoryAdministrativeUnitMember @addMemberParams
-
+                    Write-Output "Created group '$DisplayName' ($GroupMembershipType membership)"
                 }
             }
-            Write-Output "Created group '$DisplayName' ($GroupMembershipType membership)"
         }
         else {
             $updateRequired = $false


### PR DESCRIPTION
Moves the Write-Output call for group creation confirmation to ensure it is always displayed after a new group is created, regardless of whether the group is directly created or added to an administrative unit.

Fix: This will prevent the display of "Created group '$DisplayName' ($GroupMembershipType membership)" during -WhatIf